### PR TITLE
Optional Values instead of Required

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ This action update the `BundleShortVersionString` and `BundleVersion` properties
 
 **Required** The relative path for the Info.plist file.
 
-### `bundle-short-version-string` 
-  
-**Required** The CF Bundle Short Version String.
+### `bundle-short-version-string`
 
-###  `bundle-version`
-    
-**Required** The CF Bundle Version.
+The CF Bundle Short Version String.
 
-###  `print-file`
+### `bundle-version`
+
+The CF Bundle Version.
+
+### `print-file`
 
 Output the Info.plist file in console before and after update.
 
@@ -26,8 +26,8 @@ Output the Info.plist file in console before and after update.
 - name: Update Info.plist
   uses: damienaicheh/update-ios-version-info-plist-action@v1.0.0
   with:
-    info-plist-path: './path_to_your/Info.plist'
-    bundle-short-version-string: '2.0'
-    bundle-version: '2'
+    info-plist-path: "./path_to_your/Info.plist"
+    bundle-short-version-string: "2.0"
+    bundle-version: "2"
     print-file: true
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,28 +21,23 @@ async function main(): Promise<void> {
         let bundleShortVersionString: string = core.getInput('bundle-short-version-string');
         let bundleVersion: string = core.getInput('bundle-version');
 
-        if (!bundleShortVersionString) {
-            core.setFailed(`Bundle Short Version String has no value: ${bundleShortVersionString}. You must define it.`);
-            process.exit(1);
-        }
-
-        if (!bundleVersion) {
-            core.setFailed(`Bundle Version has no value: ${bundleVersion}. You must define it.`);
-            process.exit(1);
-        }
-
         if (printFile) {
             core.info('Before update:');
             await exec.exec('cat', [infoPlistPath]);
         }
 
-
         let fileContent = fs.readFileSync(infoPlistPath, { encoding: 'utf8' });
         core.debug(JSON.stringify(fileContent));
 
         let obj = plist.parse(fileContent);
-        obj['CFBundleShortVersionString'] = bundleShortVersionString;
-        obj['CFBundleVersion'] = bundleVersion;
+        if (bundleShortVersionString) {
+            core.info(`Overriding CFBundleShortVersionString: ${bundleShortVersionString}`);
+            obj['CFBundleShortVersionString'] = bundleShortVersionString;
+        }
+        if(bundleVersion) {
+            core.info(`Overriding CFBundleVersion: ${bundleVersion}`);
+            obj['CFBundleVersion'] = bundleVersion;
+        }
 
         fs.chmodSync(infoPlistPath, "600");
         fs.writeFileSync(infoPlistPath, plist.build(obj));
@@ -51,8 +46,8 @@ async function main(): Promise<void> {
             core.info('After update:');
             await exec.exec('cat', [infoPlistPath]);
         }
-
-        core.info(`Info.plist updated successfully with CFBundleShortVersionString: ${bundleShortVersionString} and CFBundleVersion: ${bundleVersion}`);
+        
+        core.info(`Info.plist updated successfully`);
     } catch (error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
Made optional values so we can modify a single one of them without the need to hardcode the other one.

On my specific case, I need to just override the bundle-version value, and leave bundle-short-version-string the same as it is on xCode.